### PR TITLE
Update config to use latest syntax

### DIFF
--- a/backend-database/serverless.yml
+++ b/backend-database/serverless.yml
@@ -1,4 +1,4 @@
-tenant: ac360 # Enter your tenant name here
+org: ac360 # Enter your tenant name here
 app: demos # Enter your application name here
 service: fullstack-database
 

--- a/backend-restapi/serverless.yml
+++ b/backend-restapi/serverless.yml
@@ -1,4 +1,4 @@
-tenant: ac360 # Enter your tenant name here
+org: ac360 # Enter your tenant name here
 app: demos # Enter your application name here
 service: fullstack-restapi # update
 
@@ -7,13 +7,13 @@ provider:
   runtime: nodejs8.10
   region: us-east-1
   environment:
-    database_submissions_name: ${state:fullstack-database.database_submissions_name}
-    database_submissions_region: ${state:fullstack-database.database_submissions_region}
+    database_submissions_name: ${output:fullstack-database.database_submissions_name}
+    database_submissions_region: ${output:fullstack-database.database_submissions_region}
   iamRoleStatements:
     - Effect: Allow
       Action:
         - dynamodb:PutItem
-      Resource: "arn:aws:dynamodb:*:*:table/${state:fullstack-database.database_submissions_name}"
+      Resource: "arn:aws:dynamodb:*:*:table/${output:fullstack-database.database_submissions_name}"
 
 functions:
   formSubmit:

--- a/backend-restapi/serverless.yml
+++ b/backend-restapi/serverless.yml
@@ -7,13 +7,13 @@ provider:
   runtime: nodejs8.10
   region: us-east-1
   environment:
-    database_submissions_name: ${output:fullstack-database.database_submissions_name}
-    database_submissions_region: ${output:fullstack-database.database_submissions_region}
+    database_submissions_name: ${output::${param:env}::fullstack-database.database_submissions_name}
+    database_submissions_region: ${output::${param:env}::fullstack-database.database_submissions_region}
   iamRoleStatements:
     - Effect: Allow
       Action:
         - dynamodb:PutItem
-      Resource: "arn:aws:dynamodb:*:*:table/${output:fullstack-database.database_submissions_name}"
+      Resource: "arn:aws:dynamodb:*:*:table/${output::${param:env}::fullstack-database.database_submissions_name}"
 
 functions:
   formSubmit:

--- a/backend-tasks/serverless.yml
+++ b/backend-tasks/serverless.yml
@@ -1,4 +1,4 @@
-tenant: ac360 # Enter your tenant name here
+org: ac360 # Enter your tenant name here
 app: demos # Enter your application name here
 service: fullstack-tasks # update
 
@@ -8,7 +8,7 @@ provider:
   stage: dev
   region: us-east-1
   environment:
-    url: ${secrets:test_endpoint}
+    url: ${param:test_endpoint}
 
 functions:
   testEndpoint:

--- a/frontend/serverless.yml
+++ b/frontend/serverless.yml
@@ -1,4 +1,4 @@
-tenant: ac360 # Enter your tenant name here
+org: ac360 # Enter your tenant name here
 app: demos # Enter your application name here
 service: fullstack-website
 


### PR DESCRIPTION
This includes a few changes per the latest syntax:

1.  Rename `tenant` to `org`
2. Rename `secrets` to `param`
3. Rename `state` to `output`
4. Uses `${param:env}` in the `${output}` to load the stage value from the deployment profile.

The last point requires all the deployment profiles associated with stages, including the default stage, to have a parameter named `env` and a value with the stage name (e.g. `dev`, `stage`, `prod`) to which the deployment profile is associated.